### PR TITLE
Integrate with fastapi

### DIFF
--- a/module3/fastapi1/health_check.py
+++ b/module3/fastapi1/health_check.py
@@ -47,14 +47,9 @@ async def submit_feedback(request: SubmitFeedbackRequest):
     # Manually call the human_feedback function with the provided parameters
     feedback_output = human_feedback(current_state.values, request.approved, request.feedback_text)
     
-    # Invoke the graph from the 'feedback' node with the output of human_feedback
-    # and let it decide the next step (summarize again or save)
-    if request.approved:
-        # If approved, the graph will transition from feedback to save
-        result = app_graph.invoke(feedback_output, config=config, name="feedback")
-    else:
-        # If not approved, the graph will transition from feedback to summarize
-        result = app_graph.invoke(feedback_output, config=config, name="feedback")
+    # Invoke the graph with the output of human_feedback
+    # The graph will decide the next step (summarize again or save) based on the 'approved' flag
+    result = app_graph.invoke(feedback_output, config=config)
 
     # After invoking, the graph would have either re-summarized or saved.
     # We need to get the latest summary from the state.


### PR DESCRIPTION
Adapt `hitl_project.py` for FastAPI integration and correct a graph transition loop in the feedback workflow.

The `decide_next` function in `hitl_project.py` was returning `"human_feedback"` when approval was `False`, but the graph's edge was configured to transition from `"feedback"` to `"summarize"`. This mismatch caused a loop, preventing the graph from correctly re-entering the feedback process. The fix changes the return value to `"feedback"` to align with the graph's defined node names. Additionally, the `human_feedback` function was refactored to accept parameters directly, removing console input for FastAPI compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-39e3ebda-0a8c-4b13-8e4e-d5b2f0dddd6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39e3ebda-0a8c-4b13-8e4e-d5b2f0dddd6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

